### PR TITLE
This uses a zero-width space to detect back-delete instead a normal space.

### DIFF
--- a/JSTokenField.xcodeproj/project.pbxproj
+++ b/JSTokenField.xcodeproj/project.pbxproj
@@ -23,6 +23,11 @@
 		1A1A06C413FEE2D900CA6645 /* tokenNormal@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A06C013FEE2D900CA6645 /* tokenNormal@2x.png */; };
 		1A1A06CF13FF000C00CA6645 /* AddressBook.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A1A06CD13FF000C00CA6645 /* AddressBook.framework */; };
 		1A1A06D013FF000C00CA6645 /* AddressBookUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A1A06CE13FF000C00CA6645 /* AddressBookUI.framework */; };
+		B71650D1144399F800EBF2C7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A1A069C13FEDEEC00CA6645 /* Foundation.framework */; };
+		B71650DB14439A0500EBF2C7 /* JSTokenField.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A1A06B913FEE01C00CA6645 /* JSTokenField.h */; };
+		B71650DC14439A0500EBF2C7 /* JSTokenField.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A1A06BA13FEE01C00CA6645 /* JSTokenField.m */; };
+		B71650DD14439A0500EBF2C7 /* JSTokenButton.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A1A06B713FEE01C00CA6645 /* JSTokenButton.h */; };
+		B71650DE14439A0500EBF2C7 /* JSTokenButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A1A06B813FEE01C00CA6645 /* JSTokenButton.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -49,6 +54,7 @@
 		1A1A06C013FEE2D900CA6645 /* tokenNormal@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "tokenNormal@2x.png"; sourceTree = "<group>"; };
 		1A1A06CD13FF000C00CA6645 /* AddressBook.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AddressBook.framework; path = System/Library/Frameworks/AddressBook.framework; sourceTree = SDKROOT; };
 		1A1A06CE13FF000C00CA6645 /* AddressBookUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AddressBookUI.framework; path = System/Library/Frameworks/AddressBookUI.framework; sourceTree = SDKROOT; };
+		B71650D0144399F800EBF2C7 /* libJSTokenFieldLibrary.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libJSTokenFieldLibrary.a; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -61,6 +67,14 @@
 				1A1A069B13FEDEEC00CA6645 /* UIKit.framework in Frameworks */,
 				1A1A069D13FEDEEC00CA6645 /* Foundation.framework in Frameworks */,
 				1A1A069F13FEDEEC00CA6645 /* CoreGraphics.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B71650CD144399F800EBF2C7 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B71650D1144399F800EBF2C7 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -80,6 +94,7 @@
 			isa = PBXGroup;
 			children = (
 				1A1A069613FEDEEC00CA6645 /* JSTokenField.app */,
+				B71650D0144399F800EBF2C7 /* libJSTokenFieldLibrary.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -130,6 +145,18 @@
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		B71650CE144399F800EBF2C7 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B71650DB14439A0500EBF2C7 /* JSTokenField.h in Headers */,
+				B71650DD14439A0500EBF2C7 /* JSTokenButton.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
 		1A1A069513FEDEEC00CA6645 /* JSTokenField */ = {
 			isa = PBXNativeTarget;
@@ -148,12 +175,30 @@
 			productReference = 1A1A069613FEDEEC00CA6645 /* JSTokenField.app */;
 			productType = "com.apple.product-type.application";
 		};
+		B71650CF144399F800EBF2C7 /* JSTokenFieldLibrary */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B71650D8144399F900EBF2C7 /* Build configuration list for PBXNativeTarget "JSTokenFieldLibrary" */;
+			buildPhases = (
+				B71650CC144399F800EBF2C7 /* Sources */,
+				B71650CD144399F800EBF2C7 /* Frameworks */,
+				B71650CE144399F800EBF2C7 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = JSTokenFieldLibrary;
+			productName = JSTokenFieldLibrary;
+			productReference = B71650D0144399F800EBF2C7 /* libJSTokenFieldLibrary.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		1A1A068D13FEDEEC00CA6645 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastUpgradeCheck = 0420;
 				ORGANIZATIONNAME = JamSoft;
 			};
 			buildConfigurationList = 1A1A069013FEDEEC00CA6645 /* Build configuration list for PBXProject "JSTokenField" */;
@@ -169,6 +214,7 @@
 			projectRoot = "";
 			targets = (
 				1A1A069513FEDEEC00CA6645 /* JSTokenField */,
+				B71650CF144399F800EBF2C7 /* JSTokenFieldLibrary */,
 			);
 		};
 /* End PBXProject section */
@@ -202,6 +248,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		B71650CC144399F800EBF2C7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B71650DC14439A0500EBF2C7 /* JSTokenField.m in Sources */,
+				B71650DE14439A0500EBF2C7 /* JSTokenButton.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXVariantGroup section */
@@ -229,7 +284,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
-				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_ARC = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -254,7 +309,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
-				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_ARC = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -295,6 +350,26 @@
 			};
 			name = Release;
 		};
+		B71650D9144399F900EBF2C7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DSTROOT = /tmp/JSTokenFieldLibrary.dst;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		B71650DA144399F900EBF2C7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DSTROOT = /tmp/JSTokenFieldLibrary.dst;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -312,6 +387,15 @@
 			buildConfigurations = (
 				1A1A06B513FEDEEC00CA6645 /* Debug */,
 				1A1A06B613FEDEEC00CA6645 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B71650D8144399F900EBF2C7 /* Build configuration list for PBXNativeTarget "JSTokenFieldLibrary" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B71650D9144399F900EBF2C7 /* Debug */,
+				B71650DA144399F900EBF2C7 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/JSTokenField/DemoViewController.m
+++ b/JSTokenField/DemoViewController.m
@@ -62,11 +62,22 @@
 	[[_toField label] setText:@"To:"];
 	[_toField setDelegate:self];
 	[self.view addSubview:_toField];
+    
+    UIView *separator1 = [[[UIView alloc] initWithFrame:CGRectMake(0, _toField.bounds.size.height-1, _toField.bounds.size.width, 1)] autorelease];
+    [separator1 setAutoresizingMask:UIViewAutoresizingFlexibleTopMargin];
+    [_toField addSubview:separator1];
+    [separator1 setBackgroundColor:[UIColor lightGrayColor]];
 	
 	_ccField = [[JSTokenField alloc] initWithFrame:CGRectMake(0, 31, 320, 31)];
 	[[_ccField label] setText:@"CC:"];
 	[_ccField setDelegate:self];
 	[self.view addSubview:_ccField];
+    
+    UIView *separator2 = [[[UIView alloc] initWithFrame:CGRectMake(0, _ccField.bounds.size.height-1, _ccField.bounds.size.width, 1)] autorelease];
+    [separator2 setAutoresizingMask:UIViewAutoresizingFlexibleTopMargin];
+    [_ccField addSubview:separator2];
+    [separator2 setBackgroundColor:[UIColor lightGrayColor]];
+
 }
 
 - (void)viewDidUnload

--- a/JSTokenField/JSTokenButton.m
+++ b/JSTokenField/JSTokenButton.m
@@ -27,6 +27,7 @@
 //
 
 #import "JSTokenButton.h"
+#import <QuartzCore/QuartzCore.h>
 
 @implementation JSTokenButton
 
@@ -44,7 +45,7 @@
 	[button setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
 	[[button titleLabel] setFont:[UIFont fontWithName:@"Helvetica Neue" size:15]];
 	[[button titleLabel] setLineBreakMode:UILineBreakModeTailTruncation];
-	[button setTitleEdgeInsets:UIEdgeInsetsMake(0, 10, 0, 10)];
+	[button setTitleEdgeInsets:UIEdgeInsetsMake(2, 10, 0, 10)];
 	
 	[button setTitle:string forState:UIControlStateNormal];
 	

--- a/JSTokenField/JSTokenField.h
+++ b/JSTokenField/JSTokenField.h
@@ -32,7 +32,8 @@
 @protocol JSTokenFieldDelegate;
 
 extern NSString *const JSTokenFieldFrameDidChangeNotification;
-extern NSString *const JSTokenFieldFrameKey;
+extern NSString *const JSTokenFieldNewFrameKey;
+extern NSString *const JSTokenFieldOldFrameKey;
 extern NSString *const JSDeletedTokenKey;
 
 @interface JSTokenField : UIView <UITextFieldDelegate> {
@@ -63,7 +64,4 @@ extern NSString *const JSDeletedTokenKey;
 - (void)tokenField:(JSTokenField *)tokenField didAddToken:(NSString *)title representedObject:(id)obj;
 - (void)tokenField:(JSTokenField *)tokenField didRemoveTokenAtIndex:(NSUInteger)index;
 
-@optional
-- (void)tokenFieldFrameWillChange:(JSTokenField *)tokenField;
-- (void)tokenField:(JSTokenField *)tokenField frameDidChange:(CGRect)newFrame;
 @end

--- a/JSTokenField/JSTokenField.m
+++ b/JSTokenField/JSTokenField.m
@@ -31,7 +31,8 @@
 #import <QuartzCore/QuartzCore.h>
 
 NSString *const JSTokenFieldFrameDidChangeNotification = @"JSTokenFieldFrameDidChangeNotification";
-NSString *const JSTokenFieldFrameKey = @"JSTokenFieldFrameKey";
+NSString *const JSTokenFieldNewFrameKey = @"JSTokenFieldNewFrameKey";
+NSString *const JSTokenFieldOldFrameKey = @"JSTokenFieldOldFrameKey";
 NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
 
 #define HEIGHT_PADDING 3
@@ -301,9 +302,12 @@ NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
 
 - (void)setFrame:(CGRect)frame
 {
+    CGRect oldFrame = self.frame;
+    
 	[super setFrame:frame];
 	
-	NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithObject:[NSValue valueWithCGRect:frame] forKey:JSTokenFieldFrameKey];
+	NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithObject:[NSValue valueWithCGRect:frame] forKey:JSTokenFieldNewFrameKey];
+    [userInfo setObject:[NSValue valueWithCGRect:oldFrame] forKey:JSTokenFieldOldFrameKey];
 	if (_deletedToken)
 	{
 		[userInfo setObject:_deletedToken forKey:JSDeletedTokenKey]; 

--- a/JSTokenField/JSTokenField.m
+++ b/JSTokenField/JSTokenField.m
@@ -46,6 +46,7 @@ NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
 - (JSTokenButton *)tokenWithString:(NSString *)string representedObject:(id)obj;
 - (void)deleteHighlightedToken;
 
+- (void)commonSetup;
 @end
 
 
@@ -65,56 +66,69 @@ NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
 	
     if ((self = [super initWithFrame:frame]))
 	{
-		[self setBackgroundColor:[UIColor colorWithRed:0.9 green:0.9 blue:0.9 alpha:1.0]];
-		UIView *separator = [[[UIView alloc] initWithFrame:CGRectMake(0, frame.size.height-1, frame.size.width, 1)] autorelease];
-		[separator setAutoresizingMask:UIViewAutoresizingFlexibleTopMargin];
-		[self addSubview:separator];
-		[separator setBackgroundColor:[UIColor lightGrayColor]];
-		
-		_label = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, 0, frame.size.height)];
-		[_label setBackgroundColor:[UIColor clearColor]];
-		[_label setTextColor:[UIColor colorWithRed:0.3 green:0.3 blue:0.3 alpha:1.0]];
-		[_label setFont:[UIFont fontWithName:@"Helvetica Neue" size:17.0]];
-		
-		[self addSubview:_label];
-		
-//		self.layer.borderColor = [[UIColor blueColor] CGColor];
-//		self.layer.borderWidth = 1.0;
-		
-		_tokens = [[NSMutableArray alloc] init];
-		
-		_hiddenTextField = [[UITextField alloc] initWithFrame:CGRectMake(0, 0 , DEFAULT_HEIGHT, DEFAULT_HEIGHT)];
-		[_hiddenTextField setHidden:YES];
-		[_hiddenTextField setDelegate:self];
-		[self addSubview:_hiddenTextField];
-		[_hiddenTextField setText:ZERO_WIDTH_SPACE_STRING];
-		
-		frame.origin.y += HEIGHT_PADDING;
-		frame.size.height -= HEIGHT_PADDING;
-		_textField = [[UITextField alloc] initWithFrame:frame];
-		[_textField setDelegate:self];
-		[_textField setBorderStyle:UITextBorderStyleNone];
-		[_textField setBackground:nil];
-		[_textField setBackgroundColor:[UIColor clearColor]];
-		
-//		[_textField.layer setBorderColor:[[UIColor redColor] CGColor]];
-//		[_textField.layer setBorderWidth:1.0];
-		
-		[_textField setText:ZERO_WIDTH_SPACE_STRING];
-		
-		[self addSubview:_textField];
-		
-		[[NSNotificationCenter defaultCenter] addObserver:self
-												 selector:@selector(handleTextDidChange:)
-													 name:UITextFieldTextDidChangeNotification
-												   object:_textField];
-		[[NSNotificationCenter defaultCenter] addObserver:self
-												 selector:@selector(handleTextDidChange:)
-													 name:UITextFieldTextDidChangeNotification
-												   object:_hiddenTextField];
+        [self commonSetup];
     }
 	
     return self;
+}
+
+- (id)initWithCoder:(NSCoder *)aDecoder {
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+        [self commonSetup];
+    }
+    return self;
+}
+
+- (void)commonSetup {
+    CGRect frame = self.frame;
+    [self setBackgroundColor:[UIColor colorWithRed:0.9 green:0.9 blue:0.9 alpha:1.0]];
+    UIView *separator = [[[UIView alloc] initWithFrame:CGRectMake(0, frame.size.height-1, frame.size.width, 1)] autorelease];
+    [separator setAutoresizingMask:UIViewAutoresizingFlexibleTopMargin];
+    [self addSubview:separator];
+    [separator setBackgroundColor:[UIColor lightGrayColor]];
+    
+    _label = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, 0, frame.size.height)];
+    [_label setBackgroundColor:[UIColor clearColor]];
+    [_label setTextColor:[UIColor colorWithRed:0.3 green:0.3 blue:0.3 alpha:1.0]];
+    [_label setFont:[UIFont fontWithName:@"Helvetica Neue" size:17.0]];
+    
+    [self addSubview:_label];
+    
+    //		self.layer.borderColor = [[UIColor blueColor] CGColor];
+    //		self.layer.borderWidth = 1.0;
+    
+    _tokens = [[NSMutableArray alloc] init];
+    
+    _hiddenTextField = [[UITextField alloc] initWithFrame:CGRectMake(0, 0 , DEFAULT_HEIGHT, DEFAULT_HEIGHT)];
+    [_hiddenTextField setHidden:YES];
+    [_hiddenTextField setDelegate:self];
+    [self addSubview:_hiddenTextField];
+    [_hiddenTextField setText:ZERO_WIDTH_SPACE_STRING];
+    
+    frame.origin.y += HEIGHT_PADDING;
+    frame.size.height -= HEIGHT_PADDING;
+    _textField = [[UITextField alloc] initWithFrame:frame];
+    [_textField setDelegate:self];
+    [_textField setBorderStyle:UITextBorderStyleNone];
+    [_textField setBackground:nil];
+    [_textField setBackgroundColor:[UIColor clearColor]];
+    
+    //		[_textField.layer setBorderColor:[[UIColor redColor] CGColor]];
+    //		[_textField.layer setBorderWidth:1.0];
+    
+    [_textField setText:ZERO_WIDTH_SPACE_STRING];
+    
+    [self addSubview:_textField];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleTextDidChange:)
+                                                 name:UITextFieldTextDidChangeNotification
+                                               object:_textField];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleTextDidChange:)
+                                                 name:UITextFieldTextDidChangeNotification
+                                               object:_hiddenTextField];
 }
 
 - (void)dealloc

--- a/JSTokenField/JSTokenField.m
+++ b/JSTokenField/JSTokenField.m
@@ -39,7 +39,9 @@ NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
 
 #define DEFAULT_HEIGHT 31
 
-@interface JSTokenField ()
+#define ZERO_WIDTH_SPACE_STRING @"\u200B"
+
+@interface JSTokenField ();
 
 - (JSTokenButton *)tokenWithString:(NSString *)string representedObject:(id)obj;
 - (void)deleteHighlightedToken;
@@ -85,7 +87,7 @@ NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
 		[_hiddenTextField setHidden:YES];
 		[_hiddenTextField setDelegate:self];
 		[self addSubview:_hiddenTextField];
-		[_hiddenTextField setText:@" "];
+		[_hiddenTextField setText:ZERO_WIDTH_SPACE_STRING];
 		
 		frame.origin.y += HEIGHT_PADDING;
 		frame.size.height -= HEIGHT_PADDING;
@@ -98,7 +100,7 @@ NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
 //		[_textField.layer setBorderColor:[[UIColor redColor] CGColor]];
 //		[_textField.layer setBorderWidth:1.0];
 		
-		[_textField setText:@" "];
+		[_textField setText:ZERO_WIDTH_SPACE_STRING];
 		
 		[self addSubview:_textField];
 		
@@ -307,16 +309,16 @@ NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
 {
 	// ensure there's always a space at the beginning
 	NSMutableString *text = [[[_textField text] mutableCopy] autorelease];
-	if (![text hasPrefix:@" "])
+	if (![text hasPrefix:ZERO_WIDTH_SPACE_STRING])
 	{
-		[text insertString:@" " atIndex:0];
+		[text insertString:ZERO_WIDTH_SPACE_STRING atIndex:0];
 		[_textField setText:text];
 	}
 }
 
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string
 {
-	if ([[textField text] isEqualToString:@" "] && [string isEqualToString:@""])
+	if ([[textField text] isEqualToString:ZERO_WIDTH_SPACE_STRING] && [string isEqualToString:@""])
 	{
 		for (JSTokenButton *token in _tokens)
 		{
@@ -385,7 +387,7 @@ NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
 		if ([[textField text] length] > 1)
 		{
 			[self addTokenWithTitle:[textField text] representedObject:[textField text]];
-			[textField setText:@" "];
+			[textField setText:ZERO_WIDTH_SPACE_STRING];
 		}
 	}
 	

--- a/JSTokenField/JSTokenField.m
+++ b/JSTokenField/JSTokenField.m
@@ -34,7 +34,7 @@ NSString *const JSTokenFieldFrameDidChangeNotification = @"JSTokenFieldFrameDidC
 NSString *const JSTokenFieldFrameKey = @"JSTokenFieldFrameKey";
 NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
 
-#define HEIGHT_PADDING 6
+#define HEIGHT_PADDING 3
 #define WIDTH_PADDING 3
 
 #define DEFAULT_HEIGHT 31
@@ -107,12 +107,13 @@ NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
     [_hiddenTextField setText:ZERO_WIDTH_SPACE_STRING];
     
     frame.origin.y += HEIGHT_PADDING;
-    frame.size.height -= HEIGHT_PADDING;
+    frame.size.height -= HEIGHT_PADDING * 2;
     _textField = [[UITextField alloc] initWithFrame:frame];
     [_textField setDelegate:self];
     [_textField setBorderStyle:UITextBorderStyleNone];
     [_textField setBackground:nil];
     [_textField setBackgroundColor:[UIColor clearColor]];
+    [_textField setContentVerticalAlignment:UIControlContentVerticalAlignmentCenter];
     
     //		[_textField.layer setBorderColor:[[UIColor redColor] CGColor]];
     //		[_textField.layer setBorderWidth:1.0];
@@ -275,7 +276,7 @@ NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
 	else
 	{
 		textFieldFrame.size.width = self.frame.size.width;
-		textFieldFrame.origin = CGPointMake(0, (currentRect.origin.y + currentRect.size.height + HEIGHT_PADDING));
+		textFieldFrame.origin = CGPointMake(_label.frame.size.width + _label.frame.origin.x + WIDTH_PADDING, (currentRect.origin.y + currentRect.size.height + HEIGHT_PADDING));
 	}
 	
 	textFieldFrame.origin.y += HEIGHT_PADDING;

--- a/JSTokenField/JSTokenField.m
+++ b/JSTokenField/JSTokenField.m
@@ -83,10 +83,6 @@ NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
 - (void)commonSetup {
     CGRect frame = self.frame;
     [self setBackgroundColor:[UIColor colorWithRed:0.9 green:0.9 blue:0.9 alpha:1.0]];
-    UIView *separator = [[[UIView alloc] initWithFrame:CGRectMake(0, frame.size.height-1, frame.size.width, 1)] autorelease];
-    [separator setAutoresizingMask:UIViewAutoresizingFlexibleTopMargin];
-    [self addSubview:separator];
-    [separator setBackgroundColor:[UIColor lightGrayColor]];
     
     _label = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, 0, frame.size.height)];
     [_label setBackgroundColor:[UIColor clearColor]];


### PR DESCRIPTION
There are still issues when the user manually drags the selection loupe to the beginning of the string and hits backspace. But at least now there's not a weird space at the beginning of the string.
