### PR TITLE
Layout fixes

### DIFF
--- a/JSTokenField/JSTokenField.m
+++ b/JSTokenField/JSTokenField.m
@@ -225,7 +225,7 @@ NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
 	CGRect currentRect = CGRectZero;
 	
 	[_label sizeToFit];
-	[_label setFrame:CGRectMake(WIDTH_PADDING, HEIGHT_PADDING*2, [_label frame].size.width, [_label frame].size.height)];
+	[_label setFrame:CGRectMake(WIDTH_PADDING, HEIGHT_PADDING, [_label frame].size.width, [_label frame].size.height + 3)];
 	
 	currentRect.origin.x += _label.frame.size.width + _label.frame.origin.x + WIDTH_PADDING;
 	
@@ -263,7 +263,8 @@ NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
 	else
 	{
 		textFieldFrame.size.width = self.frame.size.width;
-		textFieldFrame.origin = CGPointMake(_label.frame.size.width + _label.frame.origin.x + WIDTH_PADDING, (currentRect.origin.y + currentRect.size.height + HEIGHT_PADDING));
+        textFieldFrame.origin = CGPointMake(WIDTH_PADDING * 2, 
+                                            (currentRect.origin.y + currentRect.size.height + HEIGHT_PADDING));
 	}
 	
 	textFieldFrame.origin.y += HEIGHT_PADDING;

--- a/JSTokenField/JSTokenField.m
+++ b/JSTokenField/JSTokenField.m
@@ -225,7 +225,7 @@ NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
 	CGRect currentRect = CGRectZero;
 	
 	[_label sizeToFit];
-	[_label setFrame:CGRectMake(WIDTH_PADDING, HEIGHT_PADDING, [_label frame].size.width, [_label frame].size.height)];
+	[_label setFrame:CGRectMake(WIDTH_PADDING, HEIGHT_PADDING*2, [_label frame].size.width, [_label frame].size.height)];
 	
 	currentRect.origin.x += _label.frame.size.width + _label.frame.origin.x + WIDTH_PADDING;
 	


### PR DESCRIPTION
Two related issues resolved here.
1. The "To:" label sat a little higher than the text in the buttons, so it looked a bit odd.
    They should have roughly the same baseline now.
2. When the text field was wrapping to a new row but the tokens hadn't wrapped there yet,
    the text field was indented flush with the end of the "To:" label. However, when you add a 
    token on that row, the token goes all the way to the left, below the label, just like Mail.app.
    This makes the text field hang below the label the way the buttons do.
