### PR TITLE
Don't modify the array of tokens while we're iterating it.

### DIFF
--- a/JSTokenField/JSTokenField.m
+++ b/JSTokenField/JSTokenField.m
@@ -163,19 +163,28 @@ NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
 
 - (void)removeTokenForString:(NSString *)string
 {
-	for (int i = 0; i < [_tokens count]; i++)
-	{
-		JSTokenButton *token = [_tokens objectAtIndex:i];
-		if ([[token titleForState:UIControlStateNormal] isEqualToString:string])
+    JSTokenButton *tokenToRemove = nil;
+    for (JSTokenButton *token in [_tokens reverseObjectEnumerator]) {
+        if ([[token titleForState:UIControlStateNormal] isEqualToString:string])
 		{
-			[token removeFromSuperview];
-			[[token retain] autorelease]; // removing it from the array will dealloc the object, but we want to keep it around for the delegate method below
-			[_tokens removeObject:token];
-			if ([self.delegate respondsToSelector:@selector(tokenField:didRemoveToken:representedObject:)])
-			{
-				[self.delegate tokenField:self didRemoveTokenAtIndex:i];
-			}
-		}
+            tokenToRemove = token;
+            break;
+        }
+    }
+    
+    if (tokenToRemove) {
+        if (tokenToRemove.isFirstResponder) {
+            [_textField becomeFirstResponder];
+        }
+        [tokenToRemove removeFromSuperview];
+        [[tokenToRemove retain] autorelease]; // removing it from the array will dealloc the object, but we want to keep it around for the delegate method below
+        
+        NSUInteger tokenIndex = [_tokens indexOfObjectIdenticalTo:tokenToRemove];
+        [_tokens removeObject:tokenToRemove];
+        if ([self.delegate respondsToSelector:@selector(tokenField:didRemoveToken:representedObject:)])
+        {
+            [self.delegate tokenField:self didRemoveTokenAtIndex:tokenIndex];
+        }
 	}
 	
 	[self setNeedsLayout];


### PR DESCRIPTION
If you had multiple tokens with the same string, trying to delete one would end up deleting a bunch of them. It could cause a crash if we tried to walk off the end of the array.

(cherry picked from commit 7be366b42e8d3bf0f99eb8a8c4e38f5b85331a42)
