### PR TITLE
fix method name which passed to respondsToSelector method.

### DIFF
--- a/JSTokenField/JSTokenField.m
+++ b/JSTokenField/JSTokenField.m
@@ -202,7 +202,7 @@ NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
 			[_deletedToken removeFromSuperview];
 			[_tokens removeObject:_deletedToken];
 			
-			if ([self.delegate respondsToSelector:@selector(tokenField:didRemoveTokenAtIndex:)])
+			if ([self.delegate respondsToSelector:@selector(tokenField:didRemove:representedObject:)])
 			{
 				NSString *tokenName = [_deletedToken titleForState:UIControlStateNormal];
 				[self.delegate tokenField:self didRemoveToken:tokenName representedObject:_deletedToken.representedObject];


### PR DESCRIPTION
I found a code to fix on previous commit.

jasarien/JSTokenField@95f6992dd6e93adcfc8bac9f39f51cb4cb40d11a
