### PR TITLE
Fix delete on iOS 6

### DIFF
--- a/JSTokenField/JSTokenField.m
+++ b/JSTokenField/JSTokenField.m
@@ -134,7 +134,7 @@ NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
 {
 	NSString *aString = [string stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
 	
-    [_textField setText:nil];
+    [_textField setText:ZERO_WIDTH_SPACE_STRING];
     
 	if ([aString length])
 	{


### PR DESCRIPTION
In iOS 6, the textDidChange handler is not called when a new token is added, so set the text to zero width space in order to get the delete key to still work properly.  (This still works in iOS 5.1)
