### PR TITLE
Fixes problem adding or removing tokens in iOS 6

### DIFF
--- a/JSTokenField/JSTokenField.m
+++ b/JSTokenField/JSTokenField.m
@@ -145,7 +145,7 @@ NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
 {
 	NSString *aString = [string stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
 	
-    [_textField setText:nil];
+    [_textField setText:ZERO_WIDTH_SPACE_STRING];
     
 	if ([aString length])
 	{


### PR DESCRIPTION
- when add token to the field, add zero width space so that backspace will delete the text
