### PR TITLE
Implemented didRemoveToken in the DemoController

### DIFF
--- a/JSTokenField/DemoViewController.m
+++ b/JSTokenField/DemoViewController.m
@@ -119,6 +119,14 @@
 
 }
 
+- (void)tokenField:(JSTokenField *)tokenField didRemoveToken:(NSString *)title representedObject:(id)obj
+{
+	NSDictionary *recipient = [NSDictionary dictionaryWithObject:obj forKey:title];
+	[_toRecipients removeObject:recipient];
+	NSLog(@"Removed token for < %@ : %@ >\n%@", title, obj, _toRecipients);
+    
+}
+
 - (void)tokenField:(JSTokenField *)tokenField didRemoveTokenAtIndex:(NSUInteger)index
 {	
 	[_toRecipients removeObjectAtIndex:index];


### PR DESCRIPTION
While incorporating JSTokenField in one of my projects I noticed that the tokens were not getting removed from the dictionary. I implemented the didRemoveToken in the DemoViewController to make it easier for first timers to incorporate the functionality provided by JSTokenField in their own projects.
