### PR TITLE
Remove ZERO_WIDTH_SPACE_STRING, relying on iOS 6 to do it right.

### DIFF
--- a/JSTokenField.xcodeproj/project.pbxproj
+++ b/JSTokenField.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		B71650DC14439A0500EBF2C7 /* JSTokenField.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A1A06BA13FEE01C00CA6645 /* JSTokenField.m */; };
 		B71650DD14439A0500EBF2C7 /* JSTokenButton.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A1A06B713FEE01C00CA6645 /* JSTokenButton.h */; };
 		B71650DE14439A0500EBF2C7 /* JSTokenButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A1A06B813FEE01C00CA6645 /* JSTokenButton.m */; };
+		B7A8303716D2D21500E7587F /* JSBackspaceReportingTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = B7A8303616D2D21500E7587F /* JSBackspaceReportingTextField.m */; };
+		B7A8303816D2D2E700E7587F /* JSBackspaceReportingTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = B7A8303616D2D21500E7587F /* JSBackspaceReportingTextField.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -55,6 +57,8 @@
 		1A1A06CD13FF000C00CA6645 /* AddressBook.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AddressBook.framework; path = System/Library/Frameworks/AddressBook.framework; sourceTree = SDKROOT; };
 		1A1A06CE13FF000C00CA6645 /* AddressBookUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AddressBookUI.framework; path = System/Library/Frameworks/AddressBookUI.framework; sourceTree = SDKROOT; };
 		B71650D0144399F800EBF2C7 /* libJSTokenFieldLibrary.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libJSTokenFieldLibrary.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		B7A8303516D2D21500E7587F /* JSBackspaceReportingTextField.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSBackspaceReportingTextField.h; sourceTree = "<group>"; };
+		B7A8303616D2D21500E7587F /* JSBackspaceReportingTextField.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSBackspaceReportingTextField.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -124,6 +128,8 @@
 				1A1A06B813FEE01C00CA6645 /* JSTokenButton.m */,
 				1A1A06AF13FEDEEC00CA6645 /* DemoViewController.xib */,
 				1A1A06A113FEDEEC00CA6645 /* Supporting Files */,
+				B7A8303516D2D21500E7587F /* JSBackspaceReportingTextField.h */,
+				B7A8303616D2D21500E7587F /* JSBackspaceReportingTextField.m */,
 			);
 			path = JSTokenField;
 			sourceTree = "<group>";
@@ -245,6 +251,7 @@
 				1A1A06AE13FEDEEC00CA6645 /* DemoViewController.m in Sources */,
 				1A1A06BB13FEE01C00CA6645 /* JSTokenButton.m in Sources */,
 				1A1A06BC13FEE01C00CA6645 /* JSTokenField.m in Sources */,
+				B7A8303716D2D21500E7587F /* JSBackspaceReportingTextField.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -254,6 +261,7 @@
 			files = (
 				B71650DC14439A0500EBF2C7 /* JSTokenField.m in Sources */,
 				B71650DE14439A0500EBF2C7 /* JSTokenButton.m in Sources */,
+				B7A8303816D2D2E700E7587F /* JSBackspaceReportingTextField.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/JSTokenField/JSBackspaceReportingTextField.h
+++ b/JSTokenField/JSBackspaceReportingTextField.h
@@ -1,0 +1,13 @@
+//
+//  JSBackspaceReportingTextField.h
+//  JSTokenField
+//
+//  Created by BJ Homer on 2/18/13.
+//  Copyright (c) 2013 JamSoft. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface JSBackspaceReportingTextField : UITextField
+
+@end

--- a/JSTokenField/JSBackspaceReportingTextField.m
+++ b/JSTokenField/JSBackspaceReportingTextField.m
@@ -1,0 +1,22 @@
+//
+//  JSBackspaceReportingTextField.m
+//  JSTokenField
+//
+//  Created by BJ Homer on 2/18/13.
+//  Copyright (c) 2013 JamSoft. All rights reserved.
+//
+
+#import "JSBackspaceReportingTextField.h"
+
+@implementation JSBackspaceReportingTextField
+
+- (void)deleteBackward {
+    [super deleteBackward];
+    if (self.text.length == 0) {
+        if ([self.delegate respondsToSelector:@selector(textField:shouldChangeCharactersInRange:replacementString:)]) {
+            [self.delegate textField:self shouldChangeCharactersInRange:NSMakeRange(0, 0) replacementString:@""];
+        }
+    }
+}
+
+@end


### PR DESCRIPTION
As of iOS 6, a UITextField subclass will receive -deleteBackward even when the text field is empty. So ZERO_WIDTH_SPACE_STRING is no longer needed there.

This also takes care of the rare case where the user dragged the insertion point back to the beginning of the field, _before_ the zero-width space. That is no longer possible.
