### PR TITLE
Align tokens on the last line vertically with the text field.

### DIFF
--- a/JSTokenField.xcodeproj/project.pbxproj
+++ b/JSTokenField.xcodeproj/project.pbxproj
@@ -47,7 +47,7 @@
 		1A1A06B713FEE01C00CA6645 /* JSTokenButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSTokenButton.h; sourceTree = "<group>"; };
 		1A1A06B813FEE01C00CA6645 /* JSTokenButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSTokenButton.m; sourceTree = "<group>"; };
 		1A1A06B913FEE01C00CA6645 /* JSTokenField.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSTokenField.h; sourceTree = "<group>"; };
-		1A1A06BA13FEE01C00CA6645 /* JSTokenField.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSTokenField.m; sourceTree = "<group>"; };
+		1A1A06BA13FEE01C00CA6645 /* JSTokenField.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSTokenField.m; sourceTree = "<group>"; usesTabs = 1; };
 		1A1A06BD13FEE2D900CA6645 /* tokenHighlighted.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tokenHighlighted.png; sourceTree = "<group>"; };
 		1A1A06BE13FEE2D900CA6645 /* tokenHighlighted@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "tokenHighlighted@2x.png"; sourceTree = "<group>"; };
 		1A1A06BF13FEE2D900CA6645 /* tokenNormal.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tokenNormal.png; sourceTree = "<group>"; };

--- a/JSTokenField/JSTokenField.m
+++ b/JSTokenField/JSTokenField.m
@@ -237,16 +237,22 @@ NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
 	CGRect currentRect = CGRectZero;
 	
 	[_label sizeToFit];
-	[_label setFrame:CGRectMake(WIDTH_PADDING, HEIGHT_PADDING, [_label frame].size.width, [_label frame].size.height + 3)];
+	[_label setFrame:CGRectMake(WIDTH_PADDING, HEIGHT_PADDING, [_label frame].size.width, [_label frame].size.height + HEIGHT_PADDING)];
 	
-	currentRect.origin.x += _label.frame.size.width + _label.frame.origin.x + WIDTH_PADDING;
+	currentRect.origin.x = _label.frame.origin.x;
+	if (_label.frame.size.width > 0) {
+		currentRect.origin.x += _label.frame.size.width + WIDTH_PADDING;
+	}
 	
+	NSMutableArray *lastLineTokens = [NSMutableArray array];
+    
 	for (UIButton *token in _tokens)
 	{
 		CGRect frame = [token frame];
 		
 		if ((currentRect.origin.x + frame.size.width) > self.frame.size.width)
 		{
+			[lastLineTokens removeAllObjects];
 			currentRect.origin = CGPointMake(WIDTH_PADDING, (currentRect.origin.y + frame.size.height + HEIGHT_PADDING));
 		}
 		
@@ -259,6 +265,7 @@ NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
 		{
 			[self addSubview:token];
 		}
+		[lastLineTokens addObject:token];
 		
 		currentRect.origin.x += frame.size.width + WIDTH_PADDING;
 		currentRect.size = frame.size;
@@ -274,6 +281,7 @@ NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
 	}
 	else
 	{
+		[lastLineTokens removeAllObjects];
 		textFieldFrame.size.width = self.frame.size.width;
         textFieldFrame.origin = CGPointMake(WIDTH_PADDING * 2, 
                                             (currentRect.origin.y + currentRect.size.height + HEIGHT_PADDING));
@@ -283,6 +291,14 @@ NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
 	[_textField setFrame:textFieldFrame];
 	CGRect selfFrame = [self frame];
 	selfFrame.size.height = textFieldFrame.origin.y + textFieldFrame.size.height + HEIGHT_PADDING;
+	
+	CGFloat textFieldMidY = CGRectGetMidY(textFieldFrame);
+	for (UIButton *token in lastLineTokens) {
+		// Center the last line's tokens vertically with the text field
+		CGPoint tokenCenter = token.center;
+		tokenCenter.y = textFieldMidY;
+		token.center = tokenCenter;
+	}
 	
 	[UIView animateWithDuration:0.3
 					 animations:^{


### PR DESCRIPTION
If the text field is larger than the JSTokenButton images, the buttons may appear to float higher than the text, which looks odd and distracting.

Note that this means that when the text field wraps to a new line, the previous line's tokens may shift vertically to fit more compactly with each other, if the text field is taller than the tokens.
