### PR TITLE
When highlighted a token, typing using keyboard should ...

### DIFF
--- a/JSTokenField/JSTokenButton.m
+++ b/JSTokenField/JSTokenButton.m
@@ -112,10 +112,20 @@
 - (BOOL)hasText {
     return NO;
 }
+
 - (void)insertText:(NSString *)text {
+    NSString *trimmedText = [text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if ([text hasPrefix:@"\n"]) {
+        [_parentField.textField becomeFirstResponder];
+    } else if ([trimmedText length] > 0) {
+        [_parentField.textField setText:trimmedText];
+        [_parentField.textField becomeFirstResponder];
+        [self deleteBackward];
+    } else {
+        [self resignFirstResponder];
+    }
     return;
 }
-
 
 - (BOOL)canBecomeFirstResponder {
     return YES;


### PR DESCRIPTION
- If enter is tapped, it should toggle the highlighted token, and ready the field for user input
- If backspace is tapped, it should clear the current token
- If any other key is tapped, it should replace current token with newly entered text
