### PR TITLE
Improve how token field handle Backspace and highligh token

### DIFF
--- a/JSTokenField/JSBackspaceReportingTextField.m
+++ b/JSTokenField/JSBackspaceReportingTextField.m
@@ -11,11 +11,11 @@
 @implementation JSBackspaceReportingTextField
 
 - (void)deleteBackward {
-    BOOL shouldDismiss = (self.text.length == 0);
+    BOOL fieldWasEmpty = (self.text.length == 0);
 
     [super deleteBackward];
 
-    if (shouldDismiss) {
+    if (fieldWasEmpty) {
         if ([self.delegate respondsToSelector:@selector(textField:shouldChangeCharactersInRange:replacementString:)]) {
             [self.delegate textField:self shouldChangeCharactersInRange:NSMakeRange(0, 0) replacementString:@""];
         }

--- a/JSTokenField/JSBackspaceReportingTextField.m
+++ b/JSTokenField/JSBackspaceReportingTextField.m
@@ -11,8 +11,11 @@
 @implementation JSBackspaceReportingTextField
 
 - (void)deleteBackward {
+    BOOL shouldDismiss = (self.text.length == 0);
+
     [super deleteBackward];
-    if (self.text.length == 0) {
+
+    if (shouldDismiss) {
         if ([self.delegate respondsToSelector:@selector(textField:shouldChangeCharactersInRange:replacementString:)]) {
             [self.delegate textField:self shouldChangeCharactersInRange:NSMakeRange(0, 0) replacementString:@""];
         }


### PR DESCRIPTION
Highlight token only when text field has NO text and user press backward (rather than the text field have ONE character and user press backward)
