### PR TITLE
Don't animate the frame around if the view isn't on screen yet.

### DIFF
--- a/JSTokenField/JSTokenField.m
+++ b/JSTokenField/JSTokenField.m
@@ -301,11 +301,16 @@ NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
 		token.center = tokenCenter;
 	}
 	
-	[UIView animateWithDuration:0.3
-					 animations:^{
-						 [self setFrame:selfFrame];
-					 }
-					 completion:nil];
+	if (self.layer.presentationLayer == nil) {
+		[self setFrame:selfFrame];
+	}
+	else {
+		[UIView animateWithDuration:0.3
+						 animations:^{
+							 [self setFrame:selfFrame];
+						 }
+						 completion:nil];
+	}
 }
 
 - (void)toggle:(id)sender


### PR DESCRIPTION
This was causing a problem when the token field was in a view that
was presented modally. `layoutSubviews` was called after the view
was added to the window, but before it had any original frame. Thus,
the animateWithDuration call here was causing it to animate from
CGRectZero, which looked odd.
