### PR TITLE
Fix a crash when removing tokens

### DIFF
--- a/JSTokenField/JSTokenField.m
+++ b/JSTokenField/JSTokenField.m
@@ -373,10 +373,17 @@ NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
 		}
 		
 		NSString *name = [token titleForState:UIControlStateNormal];
+
 		// If we don't allow deleting the token, don't even bother letting it highlight
-		if ([self.delegate tokenField:self shouldRemoveToken:name representedObject:token.representedObject]) {
+		BOOL shouldHighlight = YES;
+		if ([self.delegate respondsToSelector:@selector(tokenField:shouldRemoveToken:representedObject:)]) {
+			shouldHighlight = [self.delegate tokenField:self shouldRemoveToken:name representedObject:token.representedObject];
+		}
+		
+		if (shouldHighlight) {
 			[token becomeFirstResponder];
 		}
+		
 		return NO;
 	}
 	


### PR DESCRIPTION
- textField:shouldChangeCharactersInRange:replacementString: must check if
  the delegate implements tokenField:shouldRemoveToken:representedObject:
  before calling it
- if the method isn't implemented, the default should be to assume
  tokens can be deleted.
