### PR TITLE
Bug fixes.

### DIFF
--- a/JSTokenField/JSBackspaceReportingTextField.m
+++ b/JSTokenField/JSBackspaceReportingTextField.m
@@ -11,8 +11,11 @@
 @implementation JSBackspaceReportingTextField
 
 - (void)deleteBackward {
+    BOOL shouldDismiss = (self.text.length == 0);
+
     [super deleteBackward];
-    if (self.text.length == 0) {
+
+    if (shouldDismiss) {
         if ([self.delegate respondsToSelector:@selector(textField:shouldChangeCharactersInRange:replacementString:)]) {
             [self.delegate textField:self shouldChangeCharactersInRange:NSMakeRange(0, 0) replacementString:@""];
         }

--- a/JSTokenField/JSTokenField.m
+++ b/JSTokenField/JSTokenField.m
@@ -374,7 +374,8 @@ NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
 		
 		NSString *name = [token titleForState:UIControlStateNormal];
 		// If we don't allow deleting the token, don't even bother letting it highlight
-		if ([self.delegate tokenField:self shouldRemoveToken:name representedObject:token.representedObject]) {
+		BOOL responds = [self.delegate respondsToSelector:@selector(tokenField:shouldRemoveToken:representedObject:)];
+		if (responds == NO || [self.delegate tokenField:self shouldRemoveToken:name representedObject:token.representedObject]) {
 			[token becomeFirstResponder];
 		}
 		return NO;


### PR DESCRIPTION
This includes a couple bug fixes.
1. I was calling an @optional delegate method without checking if the delegate implements it. This was added in one of my previous pull requests. Sorry!
2. A bug in the delete-backward detection made it select the previous JSTokenButton when you deleted the last character, rather than when you hit delete and there were already no characters. Also my fault.
