### PR TITLE
Notification for secondary click on selected token

### DIFF
--- a/JSTokenField/JSTokenField.h
+++ b/JSTokenField/JSTokenField.h
@@ -32,6 +32,8 @@
 @protocol JSTokenFieldDelegate;
 
 extern NSString *const JSTokenFieldFrameDidChangeNotification;
+extern NSString *const JSTokenFieldTokenSecondTapNotification;
+
 extern NSString *const JSTokenFieldNewFrameKey;
 extern NSString *const JSTokenFieldOldFrameKey;
 extern NSString *const JSDeletedTokenKey;

--- a/JSTokenField/JSTokenField.m
+++ b/JSTokenField/JSTokenField.m
@@ -32,6 +32,7 @@
 #import <QuartzCore/QuartzCore.h>
 
 NSString *const JSTokenFieldFrameDidChangeNotification = @"JSTokenFieldFrameDidChangeNotification";
+NSString *const JSTokenFieldTokenSecondTapNotification = @"JSTokenFieldTokenSecondTapNotification";
 NSString *const JSTokenFieldNewFrameKey = @"JSTokenFieldNewFrameKey";
 NSString *const JSTokenFieldOldFrameKey = @"JSTokenFieldOldFrameKey";
 NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
@@ -324,12 +325,16 @@ NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
 
 - (void)toggle:(id)sender
 {
-	for (JSTokenButton *token in _tokens)
+	JSTokenButton *token = (JSTokenButton *)sender;
+	if (token.toggled) {
+		[[NSNotificationCenter defaultCenter] postNotificationName:JSTokenFieldTokenSecondTapNotification object:token];
+	}
+
+	for (JSTokenButton *t in _tokens)
 	{
-		[token setToggled:NO];
+		[t setToggled:NO];
 	}
 	
-	JSTokenButton *token = (JSTokenButton *)sender;
 	[token setToggled:YES];
     [token becomeFirstResponder];
 }


### PR DESCRIPTION
I've been using JSTokenField for my app and it's been great.  I wanted to add a behavior similar to iPhone's Mail app.

In Mail app, a token is selected when you tap one of them in To field.  This behavior is in JSTokenField.  When you tap already selected token, it shows detail info view.  

I've implemented it by introducing `JSTokenFieldTokenSecondTapNotification`.

It would be great if I can do something like Mail app does.  I'm happy to make changes, so please advise.

Thanks,
-gaku
