### PR TITLE
Fixed warning when checking if delegate implements callback

### DIFF
--- a/JSTokenField/JSTokenField.m
+++ b/JSTokenField/JSTokenField.m
@@ -213,7 +213,7 @@ NSString *const JSDeletedTokenKey = @"JSDeletedTokenKey";
 			[_deletedToken removeFromSuperview];
 			[_tokens removeObject:_deletedToken];
 			
-			if ([self.delegate respondsToSelector:@selector(tokenField:didRemove:representedObject:)])
+			if ([self.delegate respondsToSelector:@selector(tokenField:didRemoveToken:representedObject:)])
 			{
 				[self.delegate tokenField:self didRemoveToken:tokenName representedObject:_deletedToken.representedObject];
 			}


### PR DESCRIPTION
It was checking for `tokenField:didRemove:representedObject:` but I think it should have been `tokenField:didRemoveToken:representedObject:`
